### PR TITLE
Add card-message postMessage event

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,33 @@ Publish help articles, FAQs, and guides through the built-in Help Center Portal.
 
 Detailed documentation is available at [chatwoot.com/help-center](https://www.chatwoot.com/help-center).
 
+### Handling card messages with postMessage
+
+When the widget receives a message of type `cards` it now emits a
+`chatwoot:card-message` event. You can listen for this event and build a
+custom product carousel in your page.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@splidejs/splide/dist/js/splide.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@splidejs/splide/dist/css/splide.min.css" />
+
+<script>
+window.addEventListener('chatwoot:card-message', function (e) {
+  const items = e.detail.content_attributes.items;
+  const root = document.getElementById('product-carousel');
+  root.innerHTML = '<div class="splide__track"><ul class="splide__list"></ul></div>';
+  const list = root.querySelector('.splide__list');
+  items.forEach(item => {
+    const li = document.createElement('li');
+    li.className = 'splide__slide';
+    li.innerHTML = `<img src="${item.media_url}" alt="${item.title}" />`;
+    list.appendChild(li);
+  });
+  new Splide(root).mount();
+});
+</script>
+```
+
 ## Translation process
 
 The translation process for Chatwoot web and mobile app is managed at [https://translate.chatwoot.com](https://translate.chatwoot.com) using Crowdin. Please read the [translation guide](https://www.chatwoot.com/docs/contributing/translating-chatwoot-to-your-language) for contributing to Chatwoot.

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -26,6 +26,7 @@ import {
   CHATWOOT_ERROR,
   CHATWOOT_POSTBACK,
   CHATWOOT_READY,
+  CHATWOOT_CARD_MESSAGE,
 } from '../widget/constants/sdkEvents';
 import { SET_USER_ERROR } from '../widget/constants/errorTypes';
 import { getUserCookieName, setCookieWithDomain } from './cookieHelpers';
@@ -213,6 +214,10 @@ export const IFrameHelper = {
         eventName: CHATWOOT_POSTBACK,
         data,
       });
+    },
+
+    'card-message'({ data }) {
+      dispatchWindowEvent({ eventName: CHATWOOT_CARD_MESSAGE, data });
     },
 
     toggleBubble: state => {

--- a/app/javascript/widget/constants/sdkEvents.js
+++ b/app/javascript/widget/constants/sdkEvents.js
@@ -5,3 +5,4 @@ export const CHATWOOT_POSTBACK = 'chatwoot:postback';
 export const CHATWOOT_READY = 'chatwoot:ready';
 export const CHATWOOT_OPENED = 'chatwoot:opened';
 export const CHATWOOT_CLOSED = 'chatwoot:closed';
+export const CHATWOOT_CARD_MESSAGE = 'chatwoot:card-message';

--- a/app/javascript/widget/helpers/actionCable.js
+++ b/app/javascript/widget/helpers/actionCable.js
@@ -65,6 +65,9 @@ class ActionCableConnector extends BaseActionCableConnector {
       eventIdentifier: CHATWOOT_ON_MESSAGE,
       data,
     });
+    if (data.content_type === 'cards') {
+      IFrameHelper.sendMessage({ event: 'card-message', data });
+    }
     if (data.sender_type === 'User') {
       playNewMessageNotificationInWidget();
     }
@@ -81,6 +84,9 @@ class ActionCableConnector extends BaseActionCableConnector {
         eventIdentifier: CHATWOOT_ON_MESSAGE,
         data,
       });
+      if (data.content_type === 'cards') {
+        IFrameHelper.sendMessage({ event: 'card-message', data });
+      }
     }
 
     this.app.$store.dispatch('conversation/addOrUpdateMessage', data);


### PR DESCRIPTION
## Summary
- send `card-message` event when card templates are delivered
- dispatch new event in SDK to browser
- document how to listen for the event to build a Splide carousel

## Testing
- `ESLINT_USE_FLAT_CONFIG=false pnpm eslint`
- `pnpm test`
- `bundle exec rubocop -a` *(fails: rbenv version `3.3.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684affe09cc08321b9d5e48fa5bb84ec